### PR TITLE
BUGBOT v2: concise persona-driven review analysis

### DIFF
--- a/BUGBOT.md
+++ b/BUGBOT.md
@@ -1,57 +1,18 @@
 # BUGBOT — mock-publisher-ruby
-> Auto-generated from PR review analysis. Do not edit manually.
-> Last updated: 2026-03-23
 
-## Overview
+> Watches for naming bugs, missing error branches, and signature/HMAC security issues in this Ruby publisher service.
 
-**Insufficient review data** — only 3 inline review comments were found across all PRs (threshold: 5). Findings below are noted for completeness but do not represent statistically recurring patterns. All three comments come from a single PR (#1, `[ACDEV-846] Authentication methods upgrade`). Overall PR review bodies contained no substantive text.
+## Code Quality
+- **Variable name mismatch**: Verify assignments like `@priceInCents = priceInDollar` — copy-paste bugs hide type and intent errors.
 
-## Findings (sparse — 3 comments total)
+## Error Handling
+- **Missing else branch**: Every conditional that assigns a variable must handle the failure path — unassigned vars cause silent failures.
 
-### Code Quality / Naming
+## Security
+- **Signature serialization**: Ensure HMAC comparison is timing-safe and serialization format is validated end-to-end.
 
-| Pattern | Affected Paths | Frequency |
-|---------|----------------|-----------|
-| Variable assigned under wrong name (copy-paste confusion between `priceInCents` and `priceInDollar`) | `controllers/player/models.rb` | ~1 comment |
-
-**Example review comment:**
-> "priceInCents = priceInDollar?" — reviewer flagged that `@priceInCents` was being set from the `priceInDollar` parameter, indicating a naming mismatch or accidental copy-paste bug.
-
----
-
-### Error Handling / Edge Cases
-
-| Pattern | Affected Paths | Frequency |
-|---------|----------------|-----------|
-| Missing `else` branch in conditional — unhandled failure path leaves variable unassigned | `controllers/player/player_controller.rb` | ~1 comment |
-
-**Example review comment:**
-> "missing 'else' part" — the signature validation block assigns `body` only on success; no error response or fallback is defined when the check fails.
-
----
-
-### Security / Implementation Quality
-
-| Pattern | Affected Paths | Frequency |
-|---------|----------------|-----------|
-| Signature serialization logic flagged for re-implementation review | `controllers/signature.rb` | ~1 comment |
-
-**Example review comment:**
-> "Check a new implementation" — reviewer requested that the HMAC/signature serialization logic be revisited, suggesting the existing approach was not production-ready.
-
----
-
-## Most Reviewed Areas
-
-| Directory | Comment Count | Main Theme |
-|-----------|---------------|------------|
-| `controllers/player/` | 2 | Naming bugs, missing error handling |
-| `controllers/` | 1 | Security / signature logic |
-
-*(Only 2 directories had comments; full top-5 ranking not possible with this dataset.)*
-
-## Action Items
-
-- [ ] Fix variable assignment bug in `controllers/player/models.rb`: `@priceInCents` is assigned from the `priceInDollar` parameter — either rename the parameter or the instance variable to be consistent.
-- [ ] Add `else` branch to the signature check in `controllers/player/player_controller.rb` to return a proper error response (e.g. 401/403) when signature validation fails.
-- [ ] Review and harden the signature serialization implementation in `controllers/signature.rb` — confirm HMAC comparison is timing-safe and the serialization format is validated end-to-end.
+## Checklist
+- [ ] All instance variable assignments match their source parameter names
+- [ ] Signature validation blocks return explicit error responses (401/403) on failure
+- [ ] HMAC comparison uses a constant-time method, not `==`
+- [ ] Signature serialization format is tested end-to-end


### PR DESCRIPTION
## BUGBOT v2 — Improved Analysis Files

Replaces the previous verbose BUGBOT.md files with a concise, persona-driven format:
- Short persona block per file declaring what the BUGBOT watches
- One-line bullet rules (no PR quotes, no frequency tables, no historical examples)
- Actionable checklist at the end
- Max 60 lines (root) / 30 lines (subdirectory)

Generated by BUGBOT improve-bugbot.sh